### PR TITLE
Configure service authentication through client constructor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,5 +116,8 @@ def springBootVersion = '1.5.6.RELEASE'
 dependencies {
   compile group: 'org.springframework', name: 'spring-web', version: '4.3.10.RELEASE'
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: springBootVersion
+
+  compile group: 'uk.gov.hmcts.reform', name: 'java-logging', version: '1.4.0'
+
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: springBootVersion
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '3.0.0'
+version '4.0.0'
 
 checkstyle.toolVersion = '7.2'
 checkstyle.configFile = new File(rootDir, "checkstyle.xml")

--- a/src/main/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClient.java
@@ -18,6 +18,7 @@ import uk.gov.hmcts.reform.pdf.service.client.exception.PDFServiceClientExceptio
 import java.net.URI;
 import java.util.Collections;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.pdf.service.client.util.Preconditions.requireNonEmpty;
@@ -26,19 +27,32 @@ public class PDFServiceClient {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PDFServiceClient.class);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
     public static final MediaType API_VERSION = MediaType.valueOf("application/vnd.uk.gov.hmcts.pdf-service.v2+json");
+
     private final RestOperations restTemplate;
+    private final Supplier<String> s2sAuthTokenSupplier;
+
     private final URI htmlEndpoint;
     private final URI healthEndpoint;
 
-    public PDFServiceClient(URI pdfServiceBaseUrl) {
-        this(new RestTemplate(), pdfServiceBaseUrl);
+    public PDFServiceClient(
+        Supplier<String> s2sAuthTokenSupplier,
+        URI pdfServiceBaseUrl
+    ) {
+        this(new RestTemplate(), s2sAuthTokenSupplier, pdfServiceBaseUrl);
     }
 
-    public PDFServiceClient(RestOperations restTemplate, URI pdfServiceBaseUrl) {
+    public PDFServiceClient(
+        RestOperations restTemplate,
+        Supplier<String> s2sAuthTokenSupplier,
+        URI pdfServiceBaseUrl
+    ) {
         requireNonNull(pdfServiceBaseUrl);
 
         this.restTemplate = restTemplate;
+        this.s2sAuthTokenSupplier = s2sAuthTokenSupplier;
+
         htmlEndpoint = pdfServiceBaseUrl.resolve("/pdfs");
         healthEndpoint = pdfServiceBaseUrl.resolve("/health");
     }

--- a/src/main/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClient.java
@@ -30,7 +30,7 @@ public class PDFServiceClient {
 
     public static final MediaType API_VERSION = MediaType.valueOf("application/vnd.uk.gov.hmcts.pdf-service.v2+json");
 
-    private final RestOperations restTemplate;
+    private final RestOperations restOperations;
     private final Supplier<String> s2sAuthTokenSupplier;
 
     private final URI htmlEndpoint;
@@ -44,13 +44,15 @@ public class PDFServiceClient {
     }
 
     public PDFServiceClient(
-        RestOperations restTemplate,
+        RestOperations restOperations,
         Supplier<String> s2sAuthTokenSupplier,
         URI pdfServiceBaseUrl
     ) {
+        requireNonNull(restOperations);
+        requireNonNull(s2sAuthTokenSupplier);
         requireNonNull(pdfServiceBaseUrl);
 
-        this.restTemplate = restTemplate;
+        this.restOperations = restOperations;
         this.s2sAuthTokenSupplier = s2sAuthTokenSupplier;
 
         htmlEndpoint = pdfServiceBaseUrl.resolve("/pdfs");
@@ -64,7 +66,7 @@ public class PDFServiceClient {
         requireNonNull(placeholders);
 
         try {
-            return restTemplate.postForObject(
+            return restOperations.postForObject(
                 htmlEndpoint,
                 createRequestEntityFor(serviceAuthToken, template, placeholders),
                 byte[].class);
@@ -84,7 +86,7 @@ public class PDFServiceClient {
 
             HttpEntity<?> entity = new HttpEntity<Object>("", httpHeaders);
 
-            ResponseEntity<InternalHealth> exchange = restTemplate.exchange(
+            ResponseEntity<InternalHealth> exchange = restOperations.exchange(
                 healthEndpoint,
                 HttpMethod.GET,
                 entity,

--- a/src/main/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClient.java
@@ -60,9 +60,7 @@ public class PDFServiceClient {
         healthEndpoint = pdfServiceBaseUrl.resolve("/health");
     }
 
-    public byte[] generateFromHtml(String serviceAuthToken,
-                                   byte[] template,
-                                   Map<String, Object> placeholders) {
+    public byte[] generateFromHtml(byte[] template, Map<String, Object> placeholders) {
         requireNonEmpty(template);
         requireNonNull(placeholders);
 

--- a/src/main/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClient.java
@@ -29,6 +29,7 @@ public class PDFServiceClient {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     public static final MediaType API_VERSION = MediaType.valueOf("application/vnd.uk.gov.hmcts.pdf-service.v2+json");
+    public static final String SERVICE_AUTHORIZATION_HEADER = "ServiceAuthorization";
 
     private final RestOperations restOperations;
     private final Supplier<String> s2sAuthTokenSupplier;
@@ -68,7 +69,7 @@ public class PDFServiceClient {
         try {
             return restOperations.postForObject(
                 htmlEndpoint,
-                createRequestEntityFor(serviceAuthToken, template, placeholders),
+                createRequestEntityFor(s2sAuthTokenSupplier.get(), template, placeholders),
                 byte[].class);
         } catch (HttpClientErrorException e) {
             throw new PDFServiceClientException("Failed to request PDF from REST endpoint", e);
@@ -111,7 +112,7 @@ public class PDFServiceClient {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(API_VERSION);
         headers.setAccept(Collections.singletonList(MediaType.APPLICATION_PDF));
-        headers.add("ServiceAuthorization", serviceAuthToken);
+        headers.add(SERVICE_AUTHORIZATION_HEADER, serviceAuthToken);
 
         GeneratePdfRequest request = new GeneratePdfRequest(new String(template), placeholders);
         try {

--- a/src/test/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClientInputChecksTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClientInputChecksTest.java
@@ -31,17 +31,17 @@ public class PDFServiceClientInputChecksTest {
 
     @Test(expected = NullPointerException.class)
     public void shouldThrowIllegalArgumentExceptionWhenGivenNullTemplate() {
-        client.generateFromHtml(null, null, emptyMap());
+        client.generateFromHtml(null, emptyMap());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowIllegalArgumentExceptionWhenGivenEmptyTemplate() {
-        client.generateFromHtml(null, new byte[] { }, emptyMap());
+        client.generateFromHtml(new byte[] { }, emptyMap());
     }
 
     @Test(expected = NullPointerException.class)
     public void shouldThrowIllegalArgumentExceptionWhenGivenNullPlaceholders() {
-        client.generateFromHtml(null, "content".getBytes(Charset.defaultCharset()), null);
+        client.generateFromHtml("content".getBytes(Charset.defaultCharset()), null);
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClientInputChecksTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClientInputChecksTest.java
@@ -19,11 +19,14 @@ public class PDFServiceClientInputChecksTest {
     @Mock
     private Supplier<String> s2sAuthTokenSupplier;
 
+    private URI testUri;
+
     private PDFServiceClient client;
 
     @Before
     public void beforeEachTest() throws URISyntaxException {
-        client = new PDFServiceClient(s2sAuthTokenSupplier, new URI("http://this-can-be-anything/"));
+        testUri = new URI("http://this-can-be-anything/");
+        client = new PDFServiceClient(s2sAuthTokenSupplier, testUri);
     }
 
     @Test(expected = NullPointerException.class)
@@ -42,8 +45,18 @@ public class PDFServiceClientInputChecksTest {
     }
 
     @Test(expected = NullPointerException.class)
-    public void constructorShouldThrowNullPointerWWhenGivenNullServiceURLString() {
-        new PDFServiceClient(null, null);
+    public void constructorShouldThrowNullPointerWhenGivenNullServiceURLString() {
+        new PDFServiceClient(s2sAuthTokenSupplier, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void constructorShouldThrowNullPointerWhenGivenNullS2SAuthTokenSupplier() {
+        new PDFServiceClient(null, testUri);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void constructorShouldThrowNullPointerWhenGivenNullRestOperationsInstance() {
+        new PDFServiceClient(null, s2sAuthTokenSupplier, testUri);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClientInputChecksTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClientInputChecksTest.java
@@ -2,20 +2,28 @@ package uk.gov.hmcts.reform.pdf.service.client;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
+import java.util.function.Supplier;
 
 import static java.util.Collections.emptyMap;
 
+@RunWith(MockitoJUnitRunner.class)
 public class PDFServiceClientInputChecksTest {
+
+    @Mock
+    private Supplier<String> s2sAuthTokenSupplier;
 
     private PDFServiceClient client;
 
     @Before
     public void beforeEachTest() throws URISyntaxException {
-        client = new PDFServiceClient(new URI("http://this-can-be-anything/"));
+        client = new PDFServiceClient(s2sAuthTokenSupplier, new URI("http://this-can-be-anything/"));
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClientTest.java
@@ -5,9 +5,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.web.client.RestOperations;
 
@@ -17,24 +19,31 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PDFServiceClientTest {
 
-    private String endpointBase = "http://localhost";
-    private RestOperations restClient = mock(RestOperations.class);
+    private static final String ENDPOINT_BASE = "http://localhost";
+    private static final String S2S_AUTH_TOKEN = "test-s2s-auth-token";
+
     @Mock
-    private Supplier<String> s2sAuthTokenSupplier;
+    private RestOperations restClient;
+    @Captor
+    private ArgumentCaptor<HttpEntity> httpEntityArgument;
+
+    private Supplier<String> s2sAuthTokenSupplier = () -> S2S_AUTH_TOKEN;
+
     private String sampleTemplate = "<html>Test</html>";
+
     private PDFServiceClient pdfServiceClient;
 
     @Before
     public void setup() {
-        pdfServiceClient = new PDFServiceClient(restClient, s2sAuthTokenSupplier, URI.create(endpointBase));
+        pdfServiceClient = new PDFServiceClient(restClient, s2sAuthTokenSupplier, URI.create(ENDPOINT_BASE));
     }
 
     @Test
@@ -43,41 +52,36 @@ public class PDFServiceClientTest {
 
         ArgumentCaptor<URI> uriArgumentCaptor = ArgumentCaptor.forClass(URI.class);
         verify(restClient).postForObject(uriArgumentCaptor.capture(), any(), any());
-        assertThat(uriArgumentCaptor.getValue().toString()).isEqualTo(endpointBase + "/pdfs");
+        assertThat(uriArgumentCaptor.getValue().toString()).isEqualTo(ENDPOINT_BASE + "/pdfs");
     }
 
     @Test
     public void request_content_type_contains_versioned_mime_type() {
         pdfServiceClient.generateFromHtml(null, sampleTemplate.getBytes(), new HashMap<>());
 
-        ArgumentCaptor<HttpEntity> httpEntityArgumentCaptor = ArgumentCaptor.forClass(HttpEntity.class);
-        verify(restClient).postForObject(any(), httpEntityArgumentCaptor.capture(), any());
+        verify(restClient).postForObject(any(), httpEntityArgument.capture(), any());
 
-        assertThat(httpEntityArgumentCaptor.getValue().getHeaders().getContentType())
+        assertThat(httpEntityArgument.getValue().getHeaders().getContentType())
             .isEqualTo(PDFServiceClient.API_VERSION);
     }
 
     @Test
     public void request_accepts_pdf() {
-        ArgumentCaptor<HttpEntity> httpEntityArgumentCaptor = ArgumentCaptor.forClass(HttpEntity.class);
-
         pdfServiceClient.generateFromHtml(null, sampleTemplate.getBytes(), new HashMap<>());
 
-        verify(restClient).postForObject(any(), httpEntityArgumentCaptor.capture(), any());
+        verify(restClient).postForObject(any(), httpEntityArgument.capture(), any());
 
-        assertThat(httpEntityArgumentCaptor.getValue().getHeaders().getAccept()).contains(MediaType.APPLICATION_PDF);
+        assertThat(httpEntityArgument.getValue().getHeaders().getAccept()).contains(MediaType.APPLICATION_PDF);
     }
 
     @Test
     public void template_contents_are_sent_in_request_template_field() throws IOException {
-        ArgumentCaptor<HttpEntity> httpEntityArgumentCaptor = ArgumentCaptor.forClass(HttpEntity.class);
-
         pdfServiceClient.generateFromHtml(null, sampleTemplate.getBytes(), new HashMap<>());
 
-        verify(restClient).postForObject(any(), httpEntityArgumentCaptor.capture(), any());
+        verify(restClient).postForObject(any(), httpEntityArgument.capture(), any());
 
         GeneratePdfRequest generatePdfRequest = new ObjectMapper()
-            .readValue(httpEntityArgumentCaptor.getValue().getBody().toString(), GeneratePdfRequest.class);
+            .readValue(httpEntityArgument.getValue().getBody().toString(), GeneratePdfRequest.class);
 
         assertThat(generatePdfRequest.template).isEqualTo(sampleTemplate);
     }
@@ -90,12 +94,22 @@ public class PDFServiceClientTest {
 
         pdfServiceClient.generateFromHtml(null, sampleTemplate.getBytes(), values);
 
-        ArgumentCaptor<HttpEntity> httpEntityArgumentCaptor = ArgumentCaptor.forClass(HttpEntity.class);
-        verify(restClient).postForObject(any(), httpEntityArgumentCaptor.capture(), any());
+        verify(restClient).postForObject(any(), httpEntityArgument.capture(), any());
 
         GeneratePdfRequest generatePdfRequest = new ObjectMapper()
-            .readValue(httpEntityArgumentCaptor.getValue().getBody().toString(), GeneratePdfRequest.class);
+            .readValue(httpEntityArgument.getValue().getBody().toString(), GeneratePdfRequest.class);
 
         assertThat(generatePdfRequest.values).containsAllEntriesOf(values).hasSameSizeAs(values);
     }
+
+    @Test
+    public void uses_provided_s2s_auth_token_supplier_when_making_a_call() {
+        pdfServiceClient.generateFromHtml(null, sampleTemplate.getBytes(), emptyMap());
+
+        verify(restClient).postForObject(any(), httpEntityArgument.capture(), any());
+
+        HttpHeaders headers = httpEntityArgument.getValue().getHeaders();
+        assertThat(headers.getFirst(PDFServiceClient.SERVICE_AUTHORIZATION_HEADER)).isEqualTo(S2S_AUTH_TOKEN);
+    }
+
 }

--- a/src/test/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClientTest.java
@@ -3,7 +3,10 @@ package uk.gov.hmcts.reform.pdf.service.client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.MediaType;
 import org.springframework.web.client.RestOperations;
@@ -12,22 +15,26 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+@RunWith(MockitoJUnitRunner.class)
 public class PDFServiceClientTest {
 
     private String endpointBase = "http://localhost";
     private RestOperations restClient = mock(RestOperations.class);
+    @Mock
+    private Supplier<String> s2sAuthTokenSupplier;
     private String sampleTemplate = "<html>Test</html>";
     private PDFServiceClient pdfServiceClient;
 
     @Before
     public void setup() {
-        pdfServiceClient = new PDFServiceClient(restClient, URI.create(endpointBase));
+        pdfServiceClient = new PDFServiceClient(restClient, s2sAuthTokenSupplier, URI.create(endpointBase));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClientTest.java
@@ -48,7 +48,7 @@ public class PDFServiceClientTest {
 
     @Test
     public void sends_requests_to_then_new_url() {
-        pdfServiceClient.generateFromHtml(null, sampleTemplate.getBytes(), new HashMap<>());
+        pdfServiceClient.generateFromHtml(sampleTemplate.getBytes(), new HashMap<>());
 
         ArgumentCaptor<URI> uriArgumentCaptor = ArgumentCaptor.forClass(URI.class);
         verify(restClient).postForObject(uriArgumentCaptor.capture(), any(), any());
@@ -57,7 +57,7 @@ public class PDFServiceClientTest {
 
     @Test
     public void request_content_type_contains_versioned_mime_type() {
-        pdfServiceClient.generateFromHtml(null, sampleTemplate.getBytes(), new HashMap<>());
+        pdfServiceClient.generateFromHtml(sampleTemplate.getBytes(), new HashMap<>());
 
         verify(restClient).postForObject(any(), httpEntityArgument.capture(), any());
 
@@ -67,7 +67,7 @@ public class PDFServiceClientTest {
 
     @Test
     public void request_accepts_pdf() {
-        pdfServiceClient.generateFromHtml(null, sampleTemplate.getBytes(), new HashMap<>());
+        pdfServiceClient.generateFromHtml(sampleTemplate.getBytes(), new HashMap<>());
 
         verify(restClient).postForObject(any(), httpEntityArgument.capture(), any());
 
@@ -76,7 +76,7 @@ public class PDFServiceClientTest {
 
     @Test
     public void template_contents_are_sent_in_request_template_field() throws IOException {
-        pdfServiceClient.generateFromHtml(null, sampleTemplate.getBytes(), new HashMap<>());
+        pdfServiceClient.generateFromHtml(sampleTemplate.getBytes(), new HashMap<>());
 
         verify(restClient).postForObject(any(), httpEntityArgument.capture(), any());
 
@@ -92,7 +92,7 @@ public class PDFServiceClientTest {
         values.put("hello", "World!");
         values.put("Foo", "bar");
 
-        pdfServiceClient.generateFromHtml(null, sampleTemplate.getBytes(), values);
+        pdfServiceClient.generateFromHtml(sampleTemplate.getBytes(), values);
 
         verify(restClient).postForObject(any(), httpEntityArgument.capture(), any());
 
@@ -104,7 +104,7 @@ public class PDFServiceClientTest {
 
     @Test
     public void uses_provided_s2s_auth_token_supplier_when_making_a_call() {
-        pdfServiceClient.generateFromHtml(null, sampleTemplate.getBytes(), emptyMap());
+        pdfServiceClient.generateFromHtml(sampleTemplate.getBytes(), emptyMap());
 
         verify(restClient).postForObject(any(), httpEntityArgument.capture(), any());
 

--- a/src/test/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClientTest.java
@@ -48,7 +48,7 @@ public class PDFServiceClientTest {
 
     @Test
     public void sends_requests_to_then_new_url() {
-        pdfServiceClient.generateFromHtml(sampleTemplate.getBytes(), new HashMap<>());
+        pdfServiceClient.generateFromHtml(sampleTemplate.getBytes(), emptyMap());
 
         ArgumentCaptor<URI> uriArgumentCaptor = ArgumentCaptor.forClass(URI.class);
         verify(restClient).postForObject(uriArgumentCaptor.capture(), any(), any());
@@ -57,7 +57,7 @@ public class PDFServiceClientTest {
 
     @Test
     public void request_content_type_contains_versioned_mime_type() {
-        pdfServiceClient.generateFromHtml(sampleTemplate.getBytes(), new HashMap<>());
+        pdfServiceClient.generateFromHtml(sampleTemplate.getBytes(), emptyMap());
 
         verify(restClient).postForObject(any(), httpEntityArgument.capture(), any());
 
@@ -67,7 +67,7 @@ public class PDFServiceClientTest {
 
     @Test
     public void request_accepts_pdf() {
-        pdfServiceClient.generateFromHtml(sampleTemplate.getBytes(), new HashMap<>());
+        pdfServiceClient.generateFromHtml(sampleTemplate.getBytes(), emptyMap());
 
         verify(restClient).postForObject(any(), httpEntityArgument.capture(), any());
 
@@ -76,7 +76,7 @@ public class PDFServiceClientTest {
 
     @Test
     public void template_contents_are_sent_in_request_template_field() throws IOException {
-        pdfServiceClient.generateFromHtml(sampleTemplate.getBytes(), new HashMap<>());
+        pdfServiceClient.generateFromHtml(sampleTemplate.getBytes(), emptyMap());
 
         verify(restClient).postForObject(any(), httpEntityArgument.capture(), any());
 


### PR DESCRIPTION
This change removes the `serviceAuthToken` input parameter from `generateFromHtml` client method and introduces a [`Supplier`](https://docs.oracle.com/javase/8/docs/api/java/util/function/Supplier.html) function to acquire those tokens.

The incentive for this change is that consumers of this client should not be concerned with the logic to acquire S2S authentication tokens and provide them for making a call. It also makes transition to a new client easier for existing consumers as they only need to change client configuration.