### PR TITLE
Enforce UTF-8 encoding

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '4.0.0'
+version '4.1.0'
 
 checkstyle.toolVersion = '7.2'
 checkstyle.configFile = new File(rootDir, "checkstyle.xml")

--- a/src/main/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClient.java
@@ -28,7 +28,8 @@ public class PDFServiceClient {
     private static final Logger LOGGER = LoggerFactory.getLogger(PDFServiceClient.class);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-    public static final MediaType API_VERSION = MediaType.valueOf("application/vnd.uk.gov.hmcts.pdf-service.v2+json");
+    public static final MediaType API_VERSION = MediaType
+        .valueOf("application/vnd.uk.gov.hmcts.pdf-service.v2+json;charset=UTF-8");
     public static final String SERVICE_AUTHORIZATION_HEADER = "ServiceAuthorization";
 
     private final RestOperations restOperations;


### PR DESCRIPTION
### Change description ###

Enforce UTF-8 encoding on the endpoint. Without that, Feign clients used a different encoding which caused JSON deserialisation to fail.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
