### PR TITLE
Allow providing custom ObjectMapper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '4.1.0'
+version '5.0.0'
 
 checkstyle.toolVersion = '7.2'
 checkstyle.configFile = new File(rootDir, "checkstyle.xml")

--- a/src/test/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClientBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClientBuilderTest.java
@@ -1,0 +1,65 @@
+package uk.gov.hmcts.reform.pdf.service.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.http.HttpEntity;
+import org.springframework.web.client.RestOperations;
+
+import java.net.URI;
+import java.util.function.Supplier;
+
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PDFServiceClientBuilderTest {
+
+    private static final byte[] TEST_TEMPLATE = "<html><body>Hello</body></html>".getBytes();
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+    @Mock
+    private RestOperations restOperations;
+    @Mock
+    private Supplier<String> s2sAuthTokenSupplier;
+
+    private URI baseUri = URI.create("https://some-host");
+
+    @Test
+    public void itShouldBePossibleToBuildClientInstanceWithDefaults() {
+        PDFServiceClient client = PDFServiceClient.builder().build(s2sAuthTokenSupplier, baseUri);
+        assertThat(client).isNotNull();
+    }
+
+    @Test
+    public void itShouldUseProvidedRestOperations() {
+        PDFServiceClient client = PDFServiceClient.builder()
+            .restOperations(restOperations)
+            .build(s2sAuthTokenSupplier, baseUri);
+
+        client.generateFromHtml(TEST_TEMPLATE, emptyMap());
+
+        verify(restOperations).postForObject(any(URI.class), any(HttpEntity.class), eq(byte[].class));
+    }
+
+    @Test
+    public void itShouldUseProvidedObjectMapper() throws Exception {
+        PDFServiceClient client = PDFServiceClient.builder()
+            .objectMapper(objectMapper)
+            .restOperations(restOperations)
+            .build(s2sAuthTokenSupplier, baseUri);
+
+        client.generateFromHtml(TEST_TEMPLATE, emptyMap());
+
+        verify(objectMapper).writeValueAsString(anyObject());
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClientInputChecksTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClientInputChecksTest.java
@@ -1,10 +1,12 @@
 package uk.gov.hmcts.reform.pdf.service.client;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.web.client.RestOperations;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -17,6 +19,10 @@ import static java.util.Collections.emptyMap;
 public class PDFServiceClientInputChecksTest {
 
     @Mock
+    private ObjectMapper objectMapper;
+    @Mock
+    private RestOperations restOperations;
+    @Mock
     private Supplier<String> s2sAuthTokenSupplier;
 
     private URI testUri;
@@ -26,7 +32,7 @@ public class PDFServiceClientInputChecksTest {
     @Before
     public void beforeEachTest() throws URISyntaxException {
         testUri = new URI("http://this-can-be-anything/");
-        client = new PDFServiceClient(s2sAuthTokenSupplier, testUri);
+        client = PDFServiceClient.builder().build(s2sAuthTokenSupplier, testUri);
     }
 
     @Test(expected = NullPointerException.class)
@@ -46,17 +52,22 @@ public class PDFServiceClientInputChecksTest {
 
     @Test(expected = NullPointerException.class)
     public void constructorShouldThrowNullPointerWhenGivenNullServiceURLString() {
-        new PDFServiceClient(s2sAuthTokenSupplier, null);
+        new PDFServiceClient(restOperations, objectMapper, s2sAuthTokenSupplier, null);
     }
 
     @Test(expected = NullPointerException.class)
     public void constructorShouldThrowNullPointerWhenGivenNullS2SAuthTokenSupplier() {
-        new PDFServiceClient(null, testUri);
+        new PDFServiceClient(restOperations, objectMapper,null, testUri);
     }
 
     @Test(expected = NullPointerException.class)
-    public void constructorShouldThrowNullPointerWhenGivenNullRestOperationsInstance() {
-        new PDFServiceClient(null, s2sAuthTokenSupplier, testUri);
+    public void constructorShouldThrowNullPointerWhenGivenNullRestOperations() {
+        new PDFServiceClient(null, objectMapper, s2sAuthTokenSupplier, testUri);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void constructorShouldThrowNullPointerWhenGivenNullObjectMapper() {
+        new PDFServiceClient(restOperations, null, s2sAuthTokenSupplier, testUri);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClientInputChecksTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClientInputChecksTest.java
@@ -57,7 +57,7 @@ public class PDFServiceClientInputChecksTest {
 
     @Test(expected = NullPointerException.class)
     public void constructorShouldThrowNullPointerWhenGivenNullS2SAuthTokenSupplier() {
-        new PDFServiceClient(restOperations, objectMapper,null, testUri);
+        new PDFServiceClient(restOperations, objectMapper, null, testUri);
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClientTest.java
@@ -43,7 +43,9 @@ public class PDFServiceClientTest {
 
     @Before
     public void setup() {
-        pdfServiceClient = new PDFServiceClient(restClient, s2sAuthTokenSupplier, URI.create(ENDPOINT_BASE));
+        pdfServiceClient = PDFServiceClient.builder()
+            .restOperations(restClient)
+            .build(s2sAuthTokenSupplier, URI.create(ENDPOINT_BASE));
     }
 
     @Test


### PR DESCRIPTION
This change gives the possibility to configure PDF service client with a custom `ObjectMapper` instance. Additionally, since the client now has 2 optional constructor parameters, I decided to provide a builder.