### PR TITLE
Stop sending s2s token

### DIFF
--- a/src/test/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClientBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClientBuilderTest.java
@@ -10,7 +10,6 @@ import org.springframework.http.HttpEntity;
 import org.springframework.web.client.RestOperations;
 
 import java.net.URI;
-import java.util.function.Supplier;
 
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,14 +27,12 @@ public class PDFServiceClientBuilderTest {
     private ObjectMapper objectMapper = new ObjectMapper();
     @Mock
     private RestOperations restOperations;
-    @Mock
-    private Supplier<String> s2sAuthTokenSupplier;
 
     private URI baseUri = URI.create("https://some-host");
 
     @Test
     public void itShouldBePossibleToBuildClientInstanceWithDefaults() {
-        PDFServiceClient client = PDFServiceClient.builder().build(s2sAuthTokenSupplier, baseUri);
+        PDFServiceClient client = PDFServiceClient.builder().build(baseUri);
         assertThat(client).isNotNull();
     }
 
@@ -43,7 +40,7 @@ public class PDFServiceClientBuilderTest {
     public void itShouldUseProvidedRestOperations() {
         PDFServiceClient client = PDFServiceClient.builder()
             .restOperations(restOperations)
-            .build(s2sAuthTokenSupplier, baseUri);
+            .build(baseUri);
 
         client.generateFromHtml(TEST_TEMPLATE, emptyMap());
 
@@ -55,7 +52,7 @@ public class PDFServiceClientBuilderTest {
         PDFServiceClient client = PDFServiceClient.builder()
             .objectMapper(objectMapper)
             .restOperations(restOperations)
-            .build(s2sAuthTokenSupplier, baseUri);
+            .build(baseUri);
 
         client.generateFromHtml(TEST_TEMPLATE, emptyMap());
 

--- a/src/test/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClientInputChecksTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClientInputChecksTest.java
@@ -11,7 +11,6 @@ import org.springframework.web.client.RestOperations;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
-import java.util.function.Supplier;
 
 import static java.util.Collections.emptyMap;
 
@@ -22,8 +21,6 @@ public class PDFServiceClientInputChecksTest {
     private ObjectMapper objectMapper;
     @Mock
     private RestOperations restOperations;
-    @Mock
-    private Supplier<String> s2sAuthTokenSupplier;
 
     private URI testUri;
 
@@ -32,7 +29,7 @@ public class PDFServiceClientInputChecksTest {
     @Before
     public void beforeEachTest() throws URISyntaxException {
         testUri = new URI("http://this-can-be-anything/");
-        client = PDFServiceClient.builder().build(s2sAuthTokenSupplier, testUri);
+        client = PDFServiceClient.builder().build(testUri);
     }
 
     @Test(expected = NullPointerException.class)
@@ -52,22 +49,17 @@ public class PDFServiceClientInputChecksTest {
 
     @Test(expected = NullPointerException.class)
     public void constructorShouldThrowNullPointerWhenGivenNullServiceURLString() {
-        new PDFServiceClient(restOperations, objectMapper, s2sAuthTokenSupplier, null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void constructorShouldThrowNullPointerWhenGivenNullS2SAuthTokenSupplier() {
-        new PDFServiceClient(restOperations, objectMapper, null, testUri);
+        new PDFServiceClient(restOperations, objectMapper, null);
     }
 
     @Test(expected = NullPointerException.class)
     public void constructorShouldThrowNullPointerWhenGivenNullRestOperations() {
-        new PDFServiceClient(null, objectMapper, s2sAuthTokenSupplier, testUri);
+        new PDFServiceClient(null, objectMapper, testUri);
     }
 
     @Test(expected = NullPointerException.class)
     public void constructorShouldThrowNullPointerWhenGivenNullObjectMapper() {
-        new PDFServiceClient(restOperations, null, s2sAuthTokenSupplier, testUri);
+        new PDFServiceClient(restOperations, null, testUri);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pdf/service/client/PDFServiceClientTest.java
@@ -28,14 +28,11 @@ import static org.mockito.Mockito.verify;
 public class PDFServiceClientTest {
 
     private static final String ENDPOINT_BASE = "http://localhost";
-    private static final String S2S_AUTH_TOKEN = "test-s2s-auth-token";
 
     @Mock
     private RestOperations restClient;
     @Captor
     private ArgumentCaptor<HttpEntity> httpEntityArgument;
-
-    private Supplier<String> s2sAuthTokenSupplier = () -> S2S_AUTH_TOKEN;
 
     private String sampleTemplate = "<html>Test</html>";
 
@@ -45,7 +42,7 @@ public class PDFServiceClientTest {
     public void setup() {
         pdfServiceClient = PDFServiceClient.builder()
             .restOperations(restClient)
-            .build(s2sAuthTokenSupplier, URI.create(ENDPOINT_BASE));
+            .build(URI.create(ENDPOINT_BASE));
     }
 
     @Test
@@ -102,16 +99,6 @@ public class PDFServiceClientTest {
             .readValue(httpEntityArgument.getValue().getBody().toString(), GeneratePdfRequest.class);
 
         assertThat(generatePdfRequest.values).containsAllEntriesOf(values).hasSameSizeAs(values);
-    }
-
-    @Test
-    public void uses_provided_s2s_auth_token_supplier_when_making_a_call() {
-        pdfServiceClient.generateFromHtml(sampleTemplate.getBytes(), emptyMap());
-
-        verify(restClient).postForObject(any(), httpEntityArgument.capture(), any());
-
-        HttpHeaders headers = httpEntityArgument.getValue().getHeaders();
-        assertThat(headers.getFirst(PDFServiceClient.SERVICE_AUTHORIZATION_HEADER)).isEqualTo(S2S_AUTH_TOKEN);
     }
 
 }


### PR DESCRIPTION
The API is no longer checking the s2s auth header (https://github.com/hmcts/cmc-pdf-service/pull/52)

I will do some additional (unrelated to s2s) cleanup on next PR and then release a new version of the lib.