### PR TITLE
Update java-logging to 6.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,7 @@ dependencies {
   compile group: 'org.springframework', name: 'spring-web'
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
 
-  compile group: 'com.github.hmcts', name: 'java-logging', version: '5.1.7'
+  compile group: 'com.github.hmcts', name: 'java-logging', version: '6.0.1'
 
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test'
 }


### PR DESCRIPTION






























































































### Change description ###
Our master is failing due java-logging
![image](https://github.com/hmcts/cmc-pdf-service-client/assets/15264837/8935efba-19b2-46a0-bc79-6e6305363be6)

Please see https://tools.hmcts.net/jira/browse/DTSPO-15102 for further info




**Does this PR introduce a breaking change?** (check one with "x")

Potentially
```
[x] Yes
[ ] No
```
